### PR TITLE
Various fixes to unbreak the codebase & testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ in the wild. Some demo samples can be [found here](https://ytaigman.github.io/lo
 ## Quick Start
 Follow the instructions in [Setup](#setup) and then simply execute:
  ```bash
- python generate.py  --npz data/vctk/numpy_features_valid/p318_212.npz --spkr 13 --checkpoint models/vctk/bestmodel.pth
+ python generate.py --spkr 10 --checkpoint models/vctk/bestmodel.pth --text "Hello, could you please say something?"
+ mplayer models/vctk/results/Hello_could_you_please_say_something.gen_10.wav
  ```
  Results will be placed in ```models/vctk/results```. It will generate 2 samples: 
   * The [generated sample](https://ytaigman.github.io/loop/demos/vctk_tutorial/p318_212.gen_10.wav) will be saved with the gen_10.wav extension.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install -r scripts/requirements.txt
 ```
 
 ### Data
-The data used to train the models in the paper can be downloaded via:
+The data used to train & run the models or run pretrained models can be downloaded via:
 ```bash
 bash scripts/download_data.sh
 ```
@@ -74,7 +74,7 @@ loop
 The preprocess pipeline can be executed using the following script by Kyle Kastner: https://gist.github.com/kastnerkyle/cc0ac48d34860c5bb3f9112f4d9a0300.
 
 ### Pretrained Models
-Pretrainde models can be downloaded via:
+Pretrained models can be downloaded via:
 ```bash
 bash scripts/download_models.sh
 ```

--- a/data.py
+++ b/data.py
@@ -168,7 +168,7 @@ class TBPTTIter(object):
         assert len(self.tgtLenths) == len(self.tgtBatch)
 
     def split_length(self, seq_size, batch_seq_len):
-        seq = [self.seq_len] * (seq_size / self.seq_len)
+        seq = [self.seq_len] * (seq_size // self.seq_len)
         if seq_size % self.seq_len != 0:
             seq += [seq_size % self.seq_len]
         seq += [0] * (batch_seq_len - len(seq))

--- a/generate.py
+++ b/generate.py
@@ -8,6 +8,8 @@ import os
 import argparse
 import numpy as np
 import phonemizer
+import phonemizer.separator as separator
+from phonemizer.phonemize import phonemize
 import string
 
 import torch
@@ -39,8 +41,8 @@ if args.gpu >= 0:
 
 
 def text2phone(text, char2code):
-    seperator = phonemizer.separator.Separator('', '', ' ')
-    ph = phonemizer.phonemize(text, separator=seperator)
+    seperator = separator.Separator('', '', ' ')
+    ph = phonemize(text, separator=seperator)
     ph = ph.split(' ')
     ph.remove('')
 

--- a/model.py
+++ b/model.py
@@ -12,9 +12,9 @@ from torch.nn.utils.rnn import pack_padded_sequence as pack
 
 
 def getLinear(dim_in, dim_out):
-    return nn.Sequential(nn.Linear(dim_in, int(dim_in/10)),
+    return nn.Sequential(nn.Linear(dim_in, dim_in//10),
                          nn.ReLU(),
-                         nn.Linear(int(dim_in/10), dim_out))
+                         nn.Linear(dim_in//10, dim_out))
 
 
 class MaskedMSE(nn.Module):
@@ -88,7 +88,7 @@ class GravesAttention(nn.Module):
         self.J = Variable(torch.arange(0, 500)
                                .expand_as(torch.Tensor(batch_size,
                                           self.K,
-                                          500)),
+                                          500)).float(),
                           requires_grad=False)
 
     def forward(self, C, context, mu_tm1):

--- a/model.py
+++ b/model.py
@@ -12,9 +12,9 @@ from torch.nn.utils.rnn import pack_padded_sequence as pack
 
 
 def getLinear(dim_in, dim_out):
-    return nn.Sequential(nn.Linear(dim_in, dim_in/10),
+    return nn.Sequential(nn.Linear(dim_in, int(dim_in/10)),
                          nn.ReLU(),
-                         nn.Linear(dim_in/10, dim_out))
+                         nn.Linear(int(dim_in/10), dim_out))
 
 
 class MaskedMSE(nn.Module):

--- a/utils.py
+++ b/utils.py
@@ -134,7 +134,7 @@ def load_binary_file_frame(file_name, dimension):
     features = numpy.fromfile(fid_lab, dtype=numpy.float32)
     fid_lab.close()
     assert features.size % float(dimension) == 0.0,'specified dimension %s not compatible with data'%(dimension)
-    frame_number = features.size / dimension
+    frame_number = int(features.size / dimension)
     features = features[:(dimension * frame_number)]
     features = features.reshape((-1, dimension))
     return features, frame_number

--- a/utils.py
+++ b/utils.py
@@ -208,7 +208,7 @@ def generate_merlin_wav(
     fw_alpha = 0.58
     co_coef = 511
 
-    sptkdir = os.path.abspath(os.path.dirname(__file__) + "/tools/SPTK-3.9/") + '/'
+    sptkdir = os.path.abspath(os.path.dirname(__file__) + "/tools/bin/SPTK-3.9/") + '/'
     sptk_path = {
         'SOPR': sptkdir + 'sopr',
         'FREQT': sptkdir + 'freqt',


### PR DESCRIPTION
Dear Authors, thank you for bringing facebookresearch / loop to the world!

This PR aggregates small fixes to various problems seen during pretrained models testing:

 * SPTK path actually needs one extra "/bin/" node
 * Implicit conversion from float to integer is disliked by Python in multiple places
 * Adding appropriate imports of Phenomizer components 
 * Changing test example to generate voice for some random text, which should be more interesting for a curious user